### PR TITLE
Fix icons not appearing in installed version of plugin

### DIFF
--- a/us.analytiq.knime.qvx/META-INF/MANIFEST.MF
+++ b/us.analytiq.knime.qvx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Qlik Connectivity for KNIME
 Bundle-SymbolicName: us.analytiq.knime.qvx.reader; singleton:=true
-Bundle-Version: 1.0.0
+Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: qvxreader.jar
 Bundle-Activator: us.analytiq.knime.qvx.reader.QvxReaderNodePlugin
 Bundle-Vendor: 

--- a/us.analytiq.knime.qvx/build.properties
+++ b/us.analytiq.knime.qvx/build.properties
@@ -1,4 +1,5 @@
 source.qvxreader.jar = src/
 bin.includes = plugin.xml,\
                META-INF/,\
-               qvxreader.jar
+               qvxreader.jar,\
+               icons/


### PR DESCRIPTION
Also adds .qualifier postfix to the plugin version, ensuring it is rebuild with a new version string.